### PR TITLE
Creado PR: Controlador de Turnos

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -28,7 +28,6 @@ config/icon="res://icon.png"
 
 window/size/width=960
 window/size/height=540
-window/size/fullscreen=true
 window/stretch/mode="viewport"
 window/stretch/aspect="keep"
 
@@ -53,6 +52,37 @@ texture={
 "size_limit": 0,
 "stream": false,
 "svg/scale": 1.0
+}
+
+[input]
+
+ui_left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+ ]
 }
 
 [rendering]

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,7 @@ config/icon="res://icon.png"
 
 window/size/width=960
 window/size/height=540
+window/size/fullscreen=true
 window/stretch/mode="viewport"
 window/stretch/aspect="keep"
 
@@ -52,37 +53,6 @@ texture={
 "size_limit": 0,
 "stream": false,
 "svg/scale": 1.0
-}
-
-[input]
-
-ui_left={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
- ]
-}
-ui_right={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
- ]
-}
-ui_up={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
- ]
-}
-ui_down={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
- ]
 }
 
 [rendering]

--- a/scenes/TestScenes/TestScene.tscn
+++ b/scenes/TestScenes/TestScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://assets/graphics/tilesets/test_tileset.png" type="Texture" id=1]
 [ext_resource path="res://scenes/Cursor/Cursor.tscn" type="PackedScene" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://scenes/Unit/Unit.tscn" type="PackedScene" id=5]
 [ext_resource path="res://scenes/TileMaps/AstarTileMap.gd" type="Script" id=6]
 [ext_resource path="res://scenes/TileMaps/TileMapFloorHilight.gd" type="Script" id=7]
+[ext_resource path="res://scenes/TurnController/TurnController.tscn" type="PackedScene" id=8]
 
 [sub_resource type="TileSet" id=1]
 0/name = "test_tileset.png 0"
@@ -70,6 +71,8 @@
 
 [node name="TestScene" type="Node2D"]
 
+[node name="TurnController" parent="." instance=ExtResource( 8 )]
+
 [node name="Camera" parent="." instance=ExtResource( 3 )]
 position = Vector2( 344, 288 )
 tolerance = 1.0
@@ -110,7 +113,34 @@ tile_data = PoolIntArray( -65534, 0, 0, -65533, 0, 0, -65532, 0, 0, -65531, 0, 0
 
 [node name="AliedUnits" type="YSort" parent="YSort"]
 
-[node name="Player" parent="YSort/AliedUnits" instance=ExtResource( 5 )]
+[node name="Player" parent="YSort/AliedUnits" groups=[
+"Soldiers",
+] instance=ExtResource( 5 )]
 position = Vector2( 303.007, 375.05 )
 
+[node name="Player2" parent="YSort/AliedUnits" groups=[
+"Soldiers",
+] instance=ExtResource( 5 )]
+position = Vector2( 328.234, 423.822 )
+
+[node name="Player3" parent="YSort/AliedUnits" groups=[
+"Soldiers",
+] instance=ExtResource( 5 )]
+position = Vector2( 240.781, 408.686 )
+
 [node name="EnemyUnits" type="YSort" parent="YSort"]
+
+[node name="Enemy" parent="YSort/EnemyUnits" groups=[
+"Enemies",
+] instance=ExtResource( 5 )]
+position = Vector2( 517.436, 246.393 )
+
+[node name="Enemy2" parent="YSort/EnemyUnits" groups=[
+"Enemies",
+] instance=ExtResource( 5 )]
+position = Vector2( 542.662, 295.165 )
+
+[node name="Enemy3" parent="YSort/EnemyUnits" groups=[
+"Enemies",
+] instance=ExtResource( 5 )]
+position = Vector2( 455.209, 280.029 )

--- a/scenes/TurnController/TurnController.gd
+++ b/scenes/TurnController/TurnController.gd
@@ -1,0 +1,99 @@
+extends Node
+
+
+enum Queue {
+	SOLDIERS,
+	ENEMIES,
+}
+
+
+var _unit_queues: Dictionary
+var _current_queue: int
+var _current_unit_index: int
+
+
+func _ready() -> void:
+	yield(get_tree().root, "ready")
+
+	_unit_queues = {
+		Queue.SOLDIERS: _get_soldiers(),
+		Queue.ENEMIES: _get_enemies(),
+	}
+	_current_queue = Queue.SOLDIERS
+	_current_unit_index = 0
+	
+	for queue in _unit_queues:
+		for unit in _unit_queues[queue]:
+			unit.connect("end_of_action", self, "_on_unit_end_of_action")
+			unit.connect("death", self, "_on_unit_death")
+	
+	select_next_unit()
+
+
+func select_next_unit() -> void:
+	var unit: Unit = _get_next_unit()
+	if unit:
+		unit.select()
+
+
+func _get_next_unit() -> Unit:
+	var unit_index: int = _current_unit_index
+	
+	while _unit_queues[_current_queue][unit_index].action_points == 0:
+		unit_index = _get_next_unit_index(unit_index)
+		if unit_index == _current_unit_index:
+			return _get_first_unit_in_next_queue()
+	_current_unit_index = _get_next_unit_index(unit_index)
+	
+	return _unit_queues[_current_queue][unit_index]
+
+
+func _get_next_unit_index(unit_index: int) -> int:
+	return wrapi(unit_index + 1, 0, _unit_queues[_current_queue].size())
+
+
+func _get_first_unit_in_next_queue() -> Unit:
+	_move_to_next_queue()
+	
+	return _get_next_unit() if _unit_queues[_current_queue].size() > 0 else null
+
+
+func _move_to_next_queue() -> void:
+	_refill_action_points_in_queue(_current_queue)
+	if _current_queue == Queue.SOLDIERS:
+		_current_queue = Queue.ENEMIES
+	else:
+		_current_queue = Queue.SOLDIERS
+	_current_unit_index = 0
+
+
+func _refill_action_points_in_queue(queue: int) -> void:
+	for unit in _unit_queues[queue]:
+		unit.refill_action_points()
+
+
+func _get_soldiers() -> Array:
+	return get_tree().get_nodes_in_group("Soldiers")
+
+
+func _get_enemies() -> Array:
+	return get_tree().get_nodes_in_group("Enemies")
+
+
+func _on_unit_end_of_action() -> void:
+	select_next_unit()
+
+
+func _on_unit_death(dead_unit: Unit) -> void:
+	if dead_unit:
+		var position: int = _unit_queues[Queue.SOLDIERS].find(dead_unit)
+		var queue: int
+		
+		if position == -1:
+			position = _unit_queues[Queue.ENEMIES].find(dead_unit)
+			queue = Queue.ENEMIES
+		else:
+			queue = Queue.SOLDIERS
+		
+		if position != -1:
+			_unit_queues[queue].remove(position)

--- a/scenes/TurnController/TurnController.gd
+++ b/scenes/TurnController/TurnController.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 		Queue.ENEMIES: _get_enemies(),
 	}
 	_current_queue = Queue.SOLDIERS
-	_current_unit_index = 0
+	_current_unit_index = -1
 	
 	for queue in _unit_queues:
 		for unit in _unit_queues[queue]:
@@ -37,15 +37,15 @@ func select_next_unit() -> void:
 
 
 func _get_next_unit() -> Unit:
-	var unit_index: int = _current_unit_index
+	var unit_index: int = _get_next_unit_index(_current_unit_index)
 	
 	while _unit_queues[_current_queue][unit_index].action_points == 0:
 		unit_index = _get_next_unit_index(unit_index)
 		if unit_index == _current_unit_index:
 			return _get_first_unit_in_next_queue()
-	_current_unit_index = _get_next_unit_index(unit_index)
+	_current_unit_index = unit_index
 	
-	return _unit_queues[_current_queue][unit_index]
+	return _unit_queues[_current_queue][_current_unit_index]
 
 
 func _get_next_unit_index(unit_index: int) -> int:
@@ -64,7 +64,7 @@ func _move_to_next_queue() -> void:
 		_current_queue = Queue.ENEMIES
 	else:
 		_current_queue = Queue.SOLDIERS
-	_current_unit_index = 0
+	_current_unit_index = -1
 
 
 func _refill_action_points_in_queue(queue: int) -> void:

--- a/scenes/TurnController/TurnController.gd
+++ b/scenes/TurnController/TurnController.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 		Queue.ENEMIES: _get_enemies(),
 	}
 	_current_queue = Queue.SOLDIERS
-	_current_unit_index = -1
+	_current_unit_index = 0
 	
 	for queue in _unit_queues:
 		for unit in _unit_queues[queue]:
@@ -37,15 +37,15 @@ func select_next_unit() -> void:
 
 
 func _get_next_unit() -> Unit:
-	var unit_index: int = _get_next_unit_index(_current_unit_index)
+	var unit_index: int = _current_unit_index
 	
 	while _unit_queues[_current_queue][unit_index].action_points == 0:
 		unit_index = _get_next_unit_index(unit_index)
 		if unit_index == _current_unit_index:
 			return _get_first_unit_in_next_queue()
-	_current_unit_index = unit_index
+	_current_unit_index = _get_next_unit_index(unit_index)
 	
-	return _unit_queues[_current_queue][_current_unit_index]
+	return _unit_queues[_current_queue][unit_index]
 
 
 func _get_next_unit_index(unit_index: int) -> int:
@@ -64,7 +64,7 @@ func _move_to_next_queue() -> void:
 		_current_queue = Queue.ENEMIES
 	else:
 		_current_queue = Queue.SOLDIERS
-	_current_unit_index = -1
+	_current_unit_index = 0
 
 
 func _refill_action_points_in_queue(queue: int) -> void:

--- a/scenes/TurnController/TurnController.tscn
+++ b/scenes/TurnController/TurnController.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/TurnController/TurnController.gd" type="Script" id=1]
+
+[node name="TurnController" type="Node"]
+script = ExtResource( 1 )

--- a/scenes/Unit/Unit.gd
+++ b/scenes/Unit/Unit.gd
@@ -30,6 +30,12 @@ func move(path)-> void:
 func select()-> void:
 	selected = true
 	soldier_sprite.modulate = Color(0.972549, 0.105882, 0.105882)
+	# Codigo de testeo para probar la rotacion de turnos con el TurnController
+	# Borrar cuando se mergee el branch
+	yield(get_tree().create_timer(1.0), "timeout")
+	action_points -= 1
+	unselect()
+	emit_signal("end_of_action")
 
 func unselect()-> void:
 	selected = false

--- a/scenes/Unit/Unit.gd
+++ b/scenes/Unit/Unit.gd
@@ -1,6 +1,11 @@
 class_name Unit
 extends Area2D
 
+
+signal end_of_action
+signal death(unit)
+
+
 export var movement_range : int = 4
 export var atack_range : int
 export var hit_points : int
@@ -29,6 +34,9 @@ func select()-> void:
 func unselect()-> void:
 	selected = false
 	soldier_sprite.modulate = Color(1, 1, 1)
+
+func refill_action_points() -> void:
+	action_points = 2
 
 func _on_Player_mouse_entered()-> void:
 	if not selected:


### PR DESCRIPTION
Creado PR de Controlador de Turnos #100 

Se creó la escena del controlador de turnos o **TurnController**.

Se crearon un par de señales en la escena Unit:
* **end_of_action**: para avisar al **TurnController** que se terminó de llevar a cabo una acción.
* **death(unit)**: que avisa que al **TurnController** la unidad murió para que se elimine de la cola de unidades.

Por ahora, para asignar el turno a una unidad simplemente llama al método **select** de la misma.

El **TurnController** crea dos colas:
* Una para las unidades del jugador, que se identifican a partir de que estén en el grupo "Soldiers".
* Y otra para los enemigos, que se identifican a partir de que estén en el grupo "Enemies".

En el **TestScene.tscn** se agregó:
- el **TurnController**
- tres unidades que están en el grupo "Soldiers"
- tres unidades que están en el grupo "Enemies".

Esto es a modo de prueba para ver la rotación rápido.

El código del método select de las unidades tiene un timer para probar la "rotación" de los turnos de unidades en la escena de prueba que *deberá ser borrado antes de aprobar el PR*.

El código de prueba consiste en que cuando se selecciona la unidad:
- se espera un segundo
- se resta un action_point a la unidad
- se emite una señal **end_of_action** para avisar al **TurnController** que le asigne el turno a la siguiente unidad